### PR TITLE
Add SSH support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/arbourd/git-open
 
 go 1.22
 
-require github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0
+require (
+	github.com/arbourd/git-get v0.5.3
+	github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0
+)
+
+require github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/arbourd/git-get v0.5.3 h1:Up6h1Bh6Jbpt4AV0v5t9Qn11WOUsuwYPgJIVfwBDbfY=
+github.com/arbourd/git-get v0.5.3/go.mod h1:/D/CsQxH8drPyEVOJOHIJXMNiThrS3xQ89SkTO3Cnvo=
 github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0 h1:o5QIusOiH9phm1gY2UGO6JQjYSPFYbgFCcntOigBvMg=
 github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0/go.mod h1:whnaSah+AmezZS8vwp8FyFzEBHZCLKywWILUj5D8Jq0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
Uses the `ParseURL()` func from `git-get` to parse SSH URLs for SSH based remotes.

Closes #2 
