### PR TITLE
Add additional Provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,35 @@ Open a different repository than `cwd`.
 $ git -C ~/src/my-repo open
 ```
 
+### Providers
+
+By default, three providers [github.com](https://github.com), [gitlab.com](https://gitlab.com) and [bitbucket.org](https://bitbucket.org) are supported.
+
+To add custom Git providers and their URLs, set their values within the global `git config`.
+
+```ini
+[open "https://git.mydomain.dev"]
+    commitprefix = commit
+    pathprefix = tree
+```
+
+This can also be set using the `git` CLI.
+
+```console
+$ git config --global open.https://git.mydomain.dev.commitprefix commit
+$ git config --global open.https://git.mydomain.dev.pathprefix tree
+```
+
+`commitprefix` and `pathprefix` are used to template the URI for your provider.
+
+```go
+fmt.Println(host + "/" + repository + "/" + commitprefix )
+// https://git.mydomain.dev/<repository>/commit
+
+fmt.Println(host + "/" + repository + "/" + pathprefix )
+// https://git.mydomain.dev/<repository>/tree
+```
+
 ## Installation
 
 Install with `brew`.

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.22
 
 require (
 	github.com/arbourd/git-get v0.6.1
+	github.com/google/go-cmp v0.6.0
 	github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/arbourd/git-get v0.6.1 h1:IYMN6gbtJcADrUpwflVR/5ERwovQ1F4nENSh7CaJnQ4=
 github.com/arbourd/git-get v0.6.1/go.mod h1:haRy2V/Odc+rDhrJhy098yNLZt0qNYu8Q752SGCHz9M=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0 h1:o5QIusOiH9phm1gY2UGO6JQjYSPFYbgFCcntOigBvMg=
 github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0/go.mod h1:whnaSah+AmezZS8vwp8FyFzEBHZCLKywWILUj5D8Jq0=

--- a/main.go
+++ b/main.go
@@ -10,20 +10,20 @@ import (
 func main() {
 	arg, err := processArgs(os.Args)
 	if err != nil {
-		fmt.Printf("Error: \"%s\"\n", err)
+		fmt.Printf("error: \"%s\"\n", err)
 		os.Exit(1)
 	}
 
 	url, err := open.GetURL(arg)
 	if err != nil {
-		fmt.Printf("Error: \"%s\"\n", err)
+		fmt.Printf("error: \"%s\"\n", err)
 		os.Exit(1)
 	}
 
 	fmt.Printf("Opening %s in your browser.\n", url)
 	err = open.InBrowser(url)
 	if err != nil {
-		fmt.Printf("Error: unable to open in browser: \"%s\"\n", err)
+		fmt.Printf("error: unable to open in browser: \"%s\"\n", err)
 		os.Exit(1)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,7 @@ func TestProcessArgs(t *testing.T) {
 	cases := map[string]struct {
 		args        []string
 		expectedArg string
-		err         string
+		wantErr     bool
 	}{
 		"no argument": {
 			args:        []string{"git-open"},
@@ -21,7 +21,7 @@ func TestProcessArgs(t *testing.T) {
 		"two arguments": {
 			args:        []string{"git-open", "LICENSE", "README.md"},
 			expectedArg: "",
-			err:         "recieved 2 args, accepts 1",
+			wantErr:     true,
 		},
 	}
 
@@ -29,10 +29,10 @@ func TestProcessArgs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			arg, err := processArgs(c.args)
 
-			if err != nil && c.err == "" {
+			if err != nil && !c.wantErr {
 				t.Fatalf("unexpected error:\n\t(GOT): %#v\n\t(WNT): nil", err)
-			} else if err == nil && len(c.err) > 0 {
-				t.Fatalf("expected error:\n\t(GOT): nil\n\t(WNT): %s", c.err)
+			} else if err == nil && c.wantErr {
+				t.Fatalf("expected error:\n\t(GOT): nil\n")
 			} else if arg != c.expectedArg {
 				t.Fatalf("unexpected arg:\n\t(GOT): %#v\n\t(WNT): %#v", arg, c.expectedArg)
 			}

--- a/open/open.go
+++ b/open/open.go
@@ -68,9 +68,11 @@ func GetURL(arg string) (string, error) {
 		return "", err
 	}
 
+	providers := append(DefaultProviders, LoadProviders()...)
+
 	// Find the provider by comparing hosts
 	var p Provider
-	for _, provider := range DefaultProviders {
+	for _, provider := range providers {
 		if strings.Contains(provider.BaseURL, host) {
 			p = provider
 			break

--- a/open/open_test.go
+++ b/open/open_test.go
@@ -20,7 +20,7 @@ func TestGetURL(t *testing.T) {
 		gitdir      string
 		arg         string
 		expectedURL string
-		err         string
+		wantErr     bool
 	}{
 		"no argument": {
 			arg:         "",
@@ -73,10 +73,10 @@ func TestGetURL(t *testing.T) {
 			}
 
 			url, err := GetURL(c.arg)
-			if err != nil && c.err == "" {
+			if err != nil && !c.wantErr {
 				t.Fatalf("unexpected error:\n\t(GOT): %#v\n\t(WNT): nil", err)
-			} else if err == nil && len(c.err) > 0 {
-				t.Fatalf("expected error:\n\t(GOT): nil\n\t(WNT): %s", c.err)
+			} else if err == nil && c.wantErr {
+				t.Fatalf("expected error:\n\t(GOT): nil\n")
 			} else if url != expectedURL {
 				t.Fatalf("unexpected url:\n\t(GOT): %#v\n\t(WNT): %#v", url, expectedURL)
 			}

--- a/open/provider.go
+++ b/open/provider.go
@@ -3,6 +3,9 @@ package open
 import (
 	"net/url"
 	"strings"
+
+	"github.com/ldez/go-git-cmd-wrapper/v2/config"
+	"github.com/ldez/go-git-cmd-wrapper/v2/git"
 )
 
 // DefaultProviders are a list of supported Providers
@@ -49,4 +52,62 @@ func (p Provider) RootURL(repo string) string {
 // escapePath escapes the URL with url.PathEscape, but unescapes `/` and trims trailing `/`
 func escapePath(u string) string {
 	return strings.TrimSuffix(strings.ReplaceAll(url.PathEscape(u), "%2F", "/"), "/")
+}
+
+const getRegex = `^open\..*prefix$`
+
+// LoadProviders returns a slice of [Provider] from the global Git config.
+//
+// The Git config structure includes a base URL as an argument, and commit prefix and path prefix keys and values.
+//
+//	[open "https://git.mydomain.dev"]
+//	  commitprefix = commit
+//	  pathprefix = tree
+func LoadProviders() []Provider {
+	p := []Provider{}
+	out, _ := git.Config(config.Global, config.GetRegexp(getRegex, ""))
+	out = strings.TrimSpace(out)
+	if len(out) == 0 {
+		return p
+	}
+
+	urls := make(map[string]*struct {
+		commitPrefix string
+		pathPrefix   string
+	})
+	for _, v := range strings.Split(out, "\n") {
+		s := strings.Split(strings.TrimPrefix(v, "open."), " ")
+
+		var value string
+		if len(s) == 2 {
+			value = s[1]
+		}
+
+		s = strings.Split(s[0], ".")
+		key := s[len(s)-1]
+		url := strings.Join(s[0:len(s)-1], ".")
+
+		if urls[url] == nil {
+			urls[url] = &struct {
+				commitPrefix string
+				pathPrefix   string
+			}{}
+		}
+
+		switch key {
+		case "commitprefix":
+			urls[url].commitPrefix = value
+		case "pathprefix":
+			urls[url].pathPrefix = value
+		}
+	}
+
+	for k, v := range urls {
+		p = append(p, Provider{
+			BaseURL:      k,
+			CommitPrefix: v.commitPrefix,
+			PathPrefix:   v.pathPrefix,
+		})
+	}
+	return p
 }


### PR DESCRIPTION
By default, only 3 providers are available. This PR adds the ability for a user to set additional Git providers with the global Git config.

The Git config structure includes a base URL as an argument, and commit prefix and path prefix keys and values.

```ini
[open "https://git.mydomain.dev"]
    commitprefix = commit
    pathprefix = tree
```

It can be set by editing the above into a .gitconfig or with the Git CLI.

```console
git config --global open.https://git.mydomain.dev.commitprefix commit
git config --global open.https://git.mydomain.dev.pathprefix tree
```

The resulting additional providers will be merged with the default providers and work with `git open` calls.
