### PR TITLE
Use rundll32 over cmd

### DIFF
--- a/open/open.go
+++ b/open/open.go
@@ -36,7 +36,7 @@ func InBrowser(url string) error {
 	case "darwin":
 		cmd = exec.Command("open", url)
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", url)
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
 	default:
 		cmd = exec.Command("xdg-open", url)
 	}


### PR DESCRIPTION
cmd allows for injection by invoking the shell rather than just opening
a link. This can be used for injection.
