### PR TITLE
Add git worktree support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-
       - run: go mod download
-      - run: go test -race ./...
 
+      - run: go vet ./...
+      - run: go test -v -race ./...
       - run: go build .
       - run: ./git-open LICENSE
 

--- a/gitw/gitw.go
+++ b/gitw/gitw.go
@@ -4,19 +4,38 @@ import (
 	"strings"
 
 	"github.com/ldez/go-git-cmd-wrapper/v2/git"
+	"github.com/ldez/go-git-cmd-wrapper/v2/revparse"
 	"github.com/ldez/go-git-cmd-wrapper/v2/types"
 )
 
-// GitDir checks if the directory is a Git repository,
+// cwd returns an option that runs the git command from the given path.
+// When path is empty the option is a no-op, leaving git to use the current directory.
+func cwd(path string) types.Option {
+	if path == "" {
+		return func(*types.Cmd) {}
+	}
+
+	return func(g *types.Cmd) {
+		g.AddBaseOptions("-C")
+		g.AddBaseOptions(path)
+	}
+}
+
+// AbsoluteGitDir returns the absolute path to the Git directory,
 // with the Git directory specified by path
 //
-// git -C path rev-parse --git-dir
-func GitDir(path string) (string, error) {
-	out, err := git.Raw("-C", func(g *types.Cmd) {
-		g.AddOptions(path)
-		g.AddOptions("rev-parse")
-		g.AddOptions("--git-dir")
-	})
+// git -C path rev-parse --absolute-git-dir
+func AbsoluteGitDir(path string) (string, error) {
+	out, err := git.RevParse(cwd(path), revparse.AbsoluteGitDir)
+	return strings.TrimSpace(out), err
+}
+
+// Toplevel returns the root of the working tree,
+// with the Git directory specified by path
+//
+// git -C path rev-parse --show-toplevel
+func Toplevel(path string) (string, error) {
+	out, err := git.RevParse(cwd(path), revparse.ShowToplevel)
 	return strings.TrimSpace(out), err
 }
 
@@ -25,24 +44,29 @@ func GitDir(path string) (string, error) {
 //
 // git -C path ls-remote --get-url
 func RemoteURL(path string) (string, error) {
-	out, err := git.Raw("-C", func(g *types.Cmd) {
-		g.AddOptions(path)
-		g.AddOptions("ls-remote")
+	out, err := git.Raw("ls-remote", cwd(path), func(g *types.Cmd) {
 		g.AddOptions("--get-url")
 	})
 	return strings.TrimSpace(out), err
 }
 
 // CurrentRef returns the current reference or branch name,
-// with the Git directory specified by path
+// with the Git directory specified by path.
+// Falls back to the full commit SHA when in detached HEAD state.
 //
 // git -C path rev-parse --abbrev-ref HEAD
+// git -C path rev-parse HEAD
 func CurrentRef(path string) (string, error) {
-	out, err := git.Raw("-C", func(g *types.Cmd) {
-		g.AddOptions(path)
-		g.AddOptions("rev-parse")
-		g.AddOptions("--abbrev-ref")
-		g.AddOptions("HEAD")
-	})
-	return strings.TrimSpace(out), err
+	out, err := git.RevParse(cwd(path), revparse.AbbrevRef(""), revparse.Args("HEAD"))
+	if err != nil {
+		return "", err
+	}
+
+	ref := strings.TrimSpace(out)
+	if ref == "HEAD" {
+		out, err = git.RevParse(cwd(path), revparse.Args("HEAD"))
+		return strings.TrimSpace(out), err
+	}
+
+	return ref, nil
 }

--- a/gitw/gitw_test.go
+++ b/gitw/gitw_test.go
@@ -1,0 +1,84 @@
+package gitw
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/ldez/go-git-cmd-wrapper/v2/types"
+)
+
+func TestCwd(t *testing.T) {
+	cases := map[string]struct {
+		path         string
+		expectedOpts []string
+	}{
+		"non-empty path": {
+			path:         "/some/path",
+			expectedOpts: []string{"-C", "/some/path"},
+		},
+		"empty path": {
+			path:         "",
+			expectedOpts: nil,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := &types.Cmd{}
+			cwd(c.path)(g)
+
+			if len(g.BaseOptions) != len(c.expectedOpts) {
+				t.Fatalf("unexpected BaseOptions:\n\t(GOT): %#v\n\t(WNT): %#v", g.BaseOptions, c.expectedOpts)
+			}
+			for i := range c.expectedOpts {
+				if g.BaseOptions[i] != c.expectedOpts[i] {
+					t.Fatalf("unexpected BaseOptions:\n\t(GOT): %#v\n\t(WNT): %#v", g.BaseOptions, c.expectedOpts)
+				}
+			}
+		})
+	}
+}
+
+func TestCurrentRef(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run("init", "-b", "test-branch")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("commit", "--allow-empty", "-m", "init")
+
+	t.Run("branch", func(t *testing.T) {
+		ref, err := CurrentRef(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref != "test-branch" {
+			t.Fatalf("unexpected ref:\n\t(GOT): %#v\n\t(WNT): %#v", ref, "test-branch")
+		}
+	})
+
+	t.Run("detached HEAD", func(t *testing.T) {
+		sha := run("rev-parse", "HEAD")
+		run("checkout", "--detach")
+
+		ref, err := CurrentRef(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ref != sha {
+			t.Fatalf("unexpected ref:\n\t(GOT): %#v\n\t(WNT): %#v", ref, sha)
+		}
+	})
+}

--- a/open/open.go
+++ b/open/open.go
@@ -2,6 +2,7 @@ package open
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -18,7 +19,7 @@ import (
 type Type int
 
 const (
-	// Folder is a specific commit in the repository
+	// Commit is a specific commit in the repository
 	Commit Type = iota
 
 	// Path is a file, folder or path in the repository
@@ -46,19 +47,27 @@ func InBrowser(url string) error {
 
 // GetURL returns the URL to open based on the arg provided
 func GetURL(arg string) (string, error) {
-	gitdir, err := gitw.GitDir(".")
+	gitroot, err := gitw.Toplevel(".")
 	if err != nil {
-		return "", fmt.Errorf("not a git repository")
+		// If toplevel fails, we might be in a bare repo
+		gitroot, err = gitw.AbsoluteGitDir(".")
+		if err != nil {
+			return "", fmt.Errorf("not a git repository")
+		}
 	}
-	gitdir, _ = filepath.Abs(gitdir)
-	gitroot := strings.TrimSuffix(gitdir, ".git")
 
 	t := parseType(arg)
+	if t == Commit {
+		if _, err := os.Stat(arg); err == nil {
+			t = Path
+		}
+	}
 	if t == Path {
+		// Ignore parsePath errors: invalid or out-of-repo paths fall back to the root URL.
 		arg, _ = parsePath(arg, gitroot)
 	}
 
-	remote, ref, err := getRemoteRef(gitdir)
+	remote, ref, err := getRemoteRef(gitroot)
 	if err != nil {
 		return "", err
 	}
@@ -67,19 +76,25 @@ func GetURL(arg string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if host == "" {
+		return "", fmt.Errorf("local remotes are not supported")
+	}
 
 	providers := append(DefaultProviders, LoadProviders()...)
 
-	// Find the provider by comparing hosts
+	// Find the provider by exact host comparison.
 	var p Provider
 	for _, provider := range providers {
-		if strings.Contains(provider.BaseURL, host) {
+		u, err := url.Parse(provider.BaseURL)
+		if err != nil {
+			continue
+		}
+		if u.Host == host {
 			p = provider
 			break
 		}
 	}
 
-	// Error if provider not found
 	if len(p.BaseURL) == 0 {
 		return "", fmt.Errorf("unable to find provider for: \"%s\"", host)
 	}
@@ -109,6 +124,9 @@ func parsePath(path, gitroot string) (string, error) {
 		return "", err
 	}
 	path, _ = filepath.Abs(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
 
 	// Check if path is within Git root
 	rel, err := filepath.Rel(gitroot, path)

--- a/open/open_test.go
+++ b/open/open_test.go
@@ -3,6 +3,7 @@ package open
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,6 +16,13 @@ func TestGetURL(t *testing.T) {
 	if err != nil {
 		panic("cannot get home directory")
 	}
+
+	f, err := os.Create("abcdef1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	t.Cleanup(func() { os.Remove("abcdef1") })
 
 	cases := map[string]struct {
 		gitdir      string
@@ -42,6 +50,10 @@ func TestGetURL(t *testing.T) {
 			arg:         "7605d91",
 			expectedURL: "https://github.com/arbourd/git-open/commit/7605d91",
 		},
+		"hex-named file": {
+			arg:         "abcdef1",
+			expectedURL: "https://github.com/arbourd/git-open/tree/%s/open/abcdef1",
+		},
 		"commit sha with extension": {
 			arg:         "7605d91.txt",
 			expectedURL: "https://github.com/arbourd/git-open/tree/%s",
@@ -64,7 +76,7 @@ func TestGetURL(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ref, err := gitw.CurrentRef(c.gitdir)
 			if err != nil {
-				panic("Unable to get local ref for test")
+				t.Fatalf("Unable to get local ref for test: %v", err)
 			}
 
 			expectedURL := c.expectedURL
@@ -79,6 +91,64 @@ func TestGetURL(t *testing.T) {
 				t.Fatalf("expected error:\n\t(GOT): nil\n")
 			} else if url != expectedURL {
 				t.Fatalf("unexpected url:\n\t(GOT): %#v\n\t(WNT): %#v", url, expectedURL)
+			}
+		})
+	}
+}
+
+func TestGetURLWorktree(t *testing.T) {
+	mainDir := t.TempDir()
+	worktreeDir := filepath.Join(t.TempDir(), "wt")
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("remote", "add", "origin", "https://github.com/example/repo.git")
+	run("commit", "--allow-empty", "-m", "init")
+	run("worktree", "add", "--detach", worktreeDir)
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, "file.txt"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(worktreeDir)
+
+	ref, err := gitw.CurrentRef(worktreeDir)
+	if err != nil {
+		t.Fatalf("unable to get ref: %v", err)
+	}
+
+	cases := map[string]struct {
+		arg         string
+		expectedURL string
+	}{
+		"root": {
+			arg:         "",
+			expectedURL: "https://github.com/example/repo",
+		},
+		"path": {
+			arg:         "file.txt",
+			expectedURL: fmt.Sprintf("https://github.com/example/repo/tree/%s/file.txt", ref),
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			url, err := GetURL(c.arg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if url != c.expectedURL {
+				t.Fatalf("unexpected url:\n\t(GOT): %#v\n\t(WNT): %#v", url, c.expectedURL)
 			}
 		})
 	}
@@ -119,6 +189,16 @@ func TestParseRepository(t *testing.T) {
 		"invalid url": {
 			remote:  "github/arbourd/git-open.git%x",
 			wantErr: true,
+		},
+		"local absolute path": {
+			remote:       "/Users/dylan/repo",
+			expectedHost: "",
+			expectedPath: "Users/dylan/repo",
+		},
+		"local relative path": {
+			remote:       "../repo",
+			expectedHost: "",
+			expectedPath: "../repo",
 		},
 	}
 
@@ -188,12 +268,10 @@ func TestParseType(t *testing.T) {
 }
 
 func TestParsePath(t *testing.T) {
-	gitdir, err := gitw.GitDir(".")
+	gitroot, err := gitw.Toplevel(".")
 	if err != nil {
 		panic("not a git repository")
 	}
-	gitdir, _ = filepath.Abs(gitdir)
-	gitroot := strings.TrimSuffix(gitdir, ".git")
 
 	cases := map[string]struct {
 		path         string

--- a/open/provider.go
+++ b/open/provider.go
@@ -71,10 +71,7 @@ func LoadProviders() []Provider {
 		return p
 	}
 
-	urls := make(map[string]*struct {
-		commitPrefix string
-		pathPrefix   string
-	})
+	urls := make(map[string]*Provider)
 	for line := range strings.SplitSeq(out, "\n") {
 		s := strings.SplitN(line, " ", 2)
 		if len(s) != 2 {
@@ -96,27 +93,21 @@ func LoadProviders() []Provider {
 
 		entry := urls[rawURL]
 		if entry == nil {
-			entry = &struct {
-				commitPrefix string
-				pathPrefix   string
-			}{}
+			entry = &Provider{}
 			urls[rawURL] = entry
 		}
 
 		switch key {
 		case "commitprefix":
-			entry.commitPrefix = value
+			entry.CommitPrefix = value
 		case "pathprefix":
-			entry.pathPrefix = value
+			entry.PathPrefix = value
 		}
 	}
 
 	for k, v := range urls {
-		p = append(p, Provider{
-			BaseURL:      k,
-			CommitPrefix: v.commitPrefix,
-			PathPrefix:   v.pathPrefix,
-		})
+		v.BaseURL = k
+		p = append(p, *v)
 	}
 
 	return p

--- a/open/provider_test.go
+++ b/open/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/ldez/go-git-cmd-wrapper/v2/config"
 	"github.com/ldez/go-git-cmd-wrapper/v2/git"
 )
@@ -126,6 +127,14 @@ func TestEscapePath(t *testing.T) {
 			url:         "https://github.com/arbourd/git-open/tree/main/file with a space.txt",
 			expectedURL: "https://github.com/arbourd/git-open/tree/main/file%20with%20a%20space.txt",
 		},
+		"trailing slash": {
+			url:         "https://github.com/arbourd/git-open/",
+			expectedURL: "https://github.com/arbourd/git-open",
+		},
+		"hash in branch": {
+			url:         "https://github.com/arbourd/git-open/tree/fix/#123",
+			expectedURL: "https://github.com/arbourd/git-open/tree/fix/%23123",
+		},
 	}
 
 	for name, c := range cases {
@@ -220,7 +229,8 @@ func TestLoadProviders(t *testing.T) {
 			if len(p) != len(c.expectedProviders) {
 				t.Logf("unexpected number of providers\n\t(GOT): %#v\n\t(WNT): %#v", len(p), len(c.expectedProviders))
 			}
-			if !cmp.Equal(p, c.expectedProviders) {
+			sortOpt := cmpopts.SortSlices(func(a, b Provider) bool { return a.BaseURL < b.BaseURL })
+			if !cmp.Equal(p, c.expectedProviders, sortOpt) {
 				t.Fatalf("unexpected providers:\n\t(GOT): %#v\n\t(WNT): %#v", p, c.expectedProviders)
 			}
 		})


### PR DESCRIPTION
Enhance Git repository detection by using 'git rev-parse --show-toplevel'
and '--absolute-git-dir', enabling native support for Git worktrees and
bare repositories. Current reference detection now correctly falls back
to full commit SHAs when in a detached HEAD state.

Modernize internal logic using Go 1.24+ iterators and simplified data
structures for provider loading.
