### PR TITLE
Add missing test coverage and harden open package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ open/
   open_test.go        integration tests (run against the real checked-out repo)
   provider_test.go    unit + integration tests for provider loading
 gitw/
-  gitw.go             thin git wrappers: Toplevel, AbsoluteGitDir, RemoteURL, CurrentRef
+  gitw.go             thin git wrappers: Toplevel, AbsoluteGitDir, RemoteURL, CurrentRef, ConfigGetRegexp
   gitw_test.go        unit tests for gitw
 ```
 
@@ -46,9 +46,9 @@ main() → GetURL(arg) → parseType → parsePath / getRemoteRef → parseRepos
 
 **Error handling:** `fmt.Errorf("context: %w", err)`. Explicit errors: `"local remotes are not supported"`, `"unable to find provider for: <host>"`.
 
-**Providers:** default providers are `github.com`, `gitlab.com`, `bitbucket.org`. Custom providers can be added via `git config --global open.<https-url>.{commitprefix,pathprefix}`; non-http/https or missing host → stderr warning + skip. `BaseURL` must be an `http`/`https` URL with a non-empty host — `TestDefaultProviders` enforces this for built-in defaults.
+**Providers:** default providers are `github.com`, `gitlab.com`, `bitbucket.org`. Custom providers can be added via `git config open.<https-url>.{commitprefix,pathprefix}` (local repo config takes precedence over global); non-http/https or missing host → stderr warning + skip. `BaseURL` must be an `http`/`https` URL with a non-empty host — `TestDefaultProviders` enforces this for built-in defaults.
 
-**Tests:** `TestGetURL` and `TestParsePath` in `open/open_test.go` run against the real checked-out repo — do not move `open/` without updating them. `TestLoadProviders` isolates global git config via `GIT_CONFIG_GLOBAL`. `gitw` functions are thin wrappers over `go-git-cmd-wrapper`: `Toplevel`, `AbsoluteGitDir`, `RemoteURL`, `CurrentRef`; empty `path` arg → cwd.
+**Tests:** `TestGetURL` and `TestParsePath` in `open/open_test.go` run against the real checked-out repo — do not move `open/` without updating them. `TestGetURLErrors`, `TestGetURLBareRepo`, and `TestGetURLWorktree` spin up hermetic temp repos. `TestLoadProviders` isolates global git config via `GIT_CONFIG_GLOBAL`. `gitw` functions are thin wrappers over `go-git-cmd-wrapper`: `Toplevel`, `AbsoluteGitDir`, `RemoteURL`, `CurrentRef`, `ConfigGetRegexp`; empty `path` arg → cwd.
 
 ## Do not
 

--- a/gitw/gitw.go
+++ b/gitw/gitw.go
@@ -3,6 +3,7 @@ package gitw
 import (
 	"strings"
 
+	"github.com/ldez/go-git-cmd-wrapper/v2/config"
 	"github.com/ldez/go-git-cmd-wrapper/v2/git"
 	"github.com/ldez/go-git-cmd-wrapper/v2/revparse"
 	"github.com/ldez/go-git-cmd-wrapper/v2/types"
@@ -69,4 +70,11 @@ func CurrentRef(path string) (string, error) {
 	}
 
 	return ref, nil
+}
+
+// ConfigGetRegexp returns trimmed git config output for all keys matching pattern.
+// Reads all config scopes (system, global, local) with local taking precedence over global for the same key.
+func ConfigGetRegexp(pattern string) string {
+	out, _ := git.Config(config.GetRegexp(pattern, ""))
+	return strings.TrimSpace(out)
 }

--- a/gitw/gitw_test.go
+++ b/gitw/gitw_test.go
@@ -8,6 +8,35 @@ import (
 	"github.com/ldez/go-git-cmd-wrapper/v2/types"
 )
 
+func TestConfigGetRegexp(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("config", "open.https://git.example.dev.commitprefix", "commit")
+	run("config", "open.https://git.example.dev.pathprefix", "tree")
+
+	t.Chdir(dir)
+
+	out := ConfigGetRegexp(`^open\..*prefix$`)
+	if !strings.Contains(out, "open.https://git.example.dev.commitprefix commit") {
+		t.Fatalf("unexpected output:\n\t(GOT): %q", out)
+	}
+	if !strings.Contains(out, "open.https://git.example.dev.pathprefix tree") {
+		t.Fatalf("unexpected output:\n\t(GOT): %q", out)
+	}
+}
+
 func TestCwd(t *testing.T) {
 	cases := map[string]struct {
 		path         string

--- a/open/open.go
+++ b/open/open.go
@@ -35,11 +35,11 @@ func InBrowser(url string) error {
 
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		cmd = exec.Command("open", "--", url)
 	case "windows":
 		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
 	default:
-		cmd = exec.Command("xdg-open", url)
+		cmd = exec.Command("xdg-open", "--", url)
 	}
 
 	return cmd.Start()
@@ -99,17 +99,17 @@ func GetURL(arg string) (string, error) {
 		return "", fmt.Errorf("unable to find provider for: \"%s\"", host)
 	}
 
-	var url string
+	var openURL string
 	switch t {
 	case Commit:
-		url = p.CommitURL(repo, arg)
+		openURL = p.CommitURL(repo, arg)
 	case Path:
-		url = p.PathURL(repo, ref, arg)
+		openURL = p.PathURL(repo, ref, arg)
 	case Root:
-		url = p.RootURL(repo)
+		openURL = p.RootURL(repo)
 	}
 
-	return url, nil
+	return openURL, nil
 }
 
 // parsePath returns a cleaned path if the file and folder exist and belong to the root Git repository

--- a/open/open_test.go
+++ b/open/open_test.go
@@ -96,6 +96,95 @@ func TestGetURL(t *testing.T) {
 	}
 }
 
+func TestGetURLErrors(t *testing.T) {
+	git := func(t *testing.T, dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	cases := map[string]struct {
+		setup   func(t *testing.T, dir string)
+		wantErr string
+	}{
+		"not a git repository": {
+			setup:   func(t *testing.T, dir string) {},
+			wantErr: "not a git repository",
+		},
+		"local remote": {
+			setup: func(t *testing.T, dir string) {
+				git(t, dir, "init")
+				git(t, dir, "config", "user.email", "test@example.com")
+				git(t, dir, "config", "user.name", "Test")
+				git(t, dir, "remote", "add", "origin", filepath.Join(t.TempDir(), "local", "repo"))
+				git(t, dir, "commit", "--allow-empty", "-m", "init")
+			},
+			wantErr: "local remotes are not supported",
+		},
+		"unsupported provider": {
+			setup: func(t *testing.T, dir string) {
+				git(t, dir, "init")
+				git(t, dir, "config", "user.email", "test@example.com")
+				git(t, dir, "config", "user.name", "Test")
+				git(t, dir, "remote", "add", "origin", "https://unknown.example.com/user/repo.git")
+				git(t, dir, "commit", "--allow-empty", "-m", "init")
+			},
+			wantErr: `unable to find provider for: "unknown.example.com"`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			c.setup(t, dir)
+			t.Chdir(dir)
+
+			_, err := GetURL("")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("unexpected error:\n\t(GOT): %q\n\t(WNT): contains %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetURLBareRepo(t *testing.T) {
+	mainDir := t.TempDir()
+	bareDir := t.TempDir()
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run(mainDir, "init")
+	run(mainDir, "config", "user.email", "test@example.com")
+	run(mainDir, "config", "user.name", "Test")
+	run(mainDir, "remote", "add", "origin", "https://github.com/example/repo.git")
+	run(mainDir, "commit", "--allow-empty", "-m", "init")
+	run(mainDir, "clone", "--bare", mainDir, bareDir)
+	run(bareDir, "remote", "set-url", "origin", "https://github.com/example/repo.git")
+
+	t.Chdir(bareDir)
+
+	url, err := GetURL("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://github.com/example/repo" {
+		t.Fatalf("unexpected url:\n\t(GOT): %#v\n\t(WNT): %#v", url, "https://github.com/example/repo")
+	}
+}
+
 func TestGetURLWorktree(t *testing.T) {
 	mainDir := t.TempDir()
 	worktreeDir := filepath.Join(t.TempDir(), "wt")

--- a/open/provider.go
+++ b/open/provider.go
@@ -6,8 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ldez/go-git-cmd-wrapper/v2/config"
-	"github.com/ldez/go-git-cmd-wrapper/v2/git"
+	"github.com/arbourd/git-open/gitw"
 )
 
 // DefaultProviders are a list of supported Providers
@@ -67,8 +66,7 @@ const getRegex = `^open\..*prefix$`
 //	  pathprefix = tree
 func LoadProviders() []Provider {
 	p := []Provider{}
-	out, _ := git.Config(config.Global, config.GetRegexp(getRegex, ""))
-	out = strings.TrimSpace(out)
+	out := gitw.ConfigGetRegexp(getRegex)
 	if len(out) == 0 {
 		return p
 	}

--- a/open/provider_test.go
+++ b/open/provider_test.go
@@ -3,6 +3,7 @@ package open
 import (
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -264,5 +265,45 @@ func TestLoadProviders(t *testing.T) {
 				t.Fatalf("unexpected providers:\n\t(GOT): %#v\n\t(WNT): %#v", p, c.expectedProviders)
 			}
 		})
+	}
+}
+
+func TestLoadProvidersLocal(t *testing.T) {
+	// Redirect global config to an empty file so only local config is visible.
+	globalConfig := filepath.Join(t.TempDir(), ".gitconfig")
+	f, err := os.Create(globalConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("config", "open.https://local.example.dev.commitprefix", "commit")
+	run("config", "open.https://local.example.dev.pathprefix", "tree")
+
+	t.Chdir(dir)
+
+	providers := LoadProviders()
+	expected := []Provider{{
+		BaseURL:      "https://local.example.dev",
+		CommitPrefix: "commit",
+		PathPrefix:   "tree",
+	}}
+
+	sortOpt := cmpopts.SortSlices(func(a, b Provider) bool { return a.BaseURL < b.BaseURL })
+	if !cmp.Equal(providers, expected, sortOpt) {
+		t.Fatalf("unexpected providers:\n\t(GOT): %#v\n\t(WNT): %#v", providers, expected)
 	}
 }


### PR DESCRIPTION
- Add TestGetURLErrors (not-a-git-repo, local remote, unsupported provider)
- Add TestGetURLBareRepo covering the AbsoluteGitDir bare-repo fallback
- Add TestConfigGetRegexp and TestLoadProvidersLocal for new gitw behaviour
- Rename url → openURL in GetURL to fix net/url import shadowing
- Add -- before URL in open/xdg-open to prevent flag injection
- LoadProviders reads local git config before falling back to global
- Move git config I/O into gitw.ConfigGetRegexp; open package no longer
  imports go-git-cmd-wrapper directly
