### PR TITLE
Add line anchors to open links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@ go test -v -race ./...
 
 ```
 main.go               CLI entry point — arg parsing only
+main_test.go          unit test for processArgs
 open/
   open.go             GetURL, InBrowser, path/type/repo parsing
-  provider.go         Provider struct, DefaultProviders, LoadProviders
+  provider.go         Provider struct, defaultProviders, Providers/fromConfig, line-format parsing (parseRawLineFormat, validateLineFormat)
   open_test.go        integration tests (run against the real checked-out repo)
   provider_test.go    unit + integration tests for provider loading
 gitw/
@@ -27,16 +28,17 @@ gitw/
 ## Data flow
 
 ```
-main() → GetURL(arg) → parseType → parsePath / getRemoteRef → parseRepository → Provider.{Commit,Path,Root}URL
+main() → GetURL(arg) → parseType → parsePath (→ stripLine) / getRemoteRef → parseRepository → Provider.{Commit,Path,Root}URL + Provider.lineAnchor
 ```
 
 1. Find repo root: `gitw.Toplevel` → falls back to `gitw.AbsoluteGitDir` (bare repos, worktrees).
 2. Classify `arg`: empty → `Root`; 7–64 hex chars → `Commit`; anything else → `Path`. If `Commit` exists on disk as a file, reclassify to `Path`.
-3. Resolve `Path` arg to a repo-relative slash path via `parsePath`; if it fails (non-existent, outside repo), silently falls back to root URL.
+3. Resolve `Path` arg to a repo-relative slash path via `parsePath`, which runs `stripLine` first to split a trailing `:line`/`:start-end` suffix (only treated as a line spec if the literal arg doesn't exist on disk; dropped for directories). Failures — missing, outside repo, or an ancestor being a file (`ancestorIsFile`, unifying POSIX `ENOTDIR` and Windows `ERROR_PATH_NOT_FOUND`) — silently fall back to root URL.
 4. Get remote URL + current ref via `getRemoteRef` (delegates to `gitw`).
 5. Parse host + repo path with `parseRepository` → delegates to `git-get`'s `get.ParseURL`.
-6. Match provider by exact host comparison: `DefaultProviders` first, then `LoadProviders()` results. URL patterns: `{BaseURL}/{repo}[/{CommitPrefix|PathPrefix}/{ref/sha}[/{path}]]`; all URLs run through `escapePath` (`url.PathEscape`, unescape `/`, trim trailing `/`).
-7. Build and return the URL.
+6. Match provider by exact host comparison: `defaultProviders` first, then `fromConfig()` results (both via `Providers()`). URL patterns: `{BaseURL}/{repo}[/{CommitPrefix|PathPrefix}/{ref/sha}[/{path}]]`; all URLs run through `escapePath` (`url.PathEscape`, unescape `/`, trim trailing `/`).
+7. For `Path` with line numbers, append `Provider.lineAnchor(start, end)`, formatting `lineFormat`/`lineFormatRange`'s `%d` verb(s) (converted from raw `%l` by `parseRawLineFormat`); falls back to the single-verb `lineFormat` (dropping `end`) when `end` is 0 or `lineFormatRange` is absent.
+8. Build and return the URL.
 
 ## Hard constraints
 
@@ -46,13 +48,13 @@ main() → GetURL(arg) → parseType → parsePath / getRemoteRef → parseRepos
 
 **Error handling:** `fmt.Errorf("context: %w", err)`. Explicit errors: `"local remotes are not supported"`, `"unable to find provider for: <host>"`.
 
-**Providers:** default providers are `github.com`, `gitlab.com`, `bitbucket.org`. Custom providers can be added via `git config open.<https-url>.{commitprefix,pathprefix}` (local repo config takes precedence over global); non-http/https or missing host → stderr warning + skip. `BaseURL` must be an `http`/`https` URL with a non-empty host — `TestDefaultProviders` enforces this for built-in defaults.
+**Providers:** default providers are `github.com`, `gitlab.com`, `bitbucket.org`, each with a `rawLineFormat` (fake `%l` verb) converted to `lineFormat`/`lineFormatRange` by `parseRawLineFormat`. Custom providers: `git config open.<https-url>.{commitprefix,pathprefix,lineformat}` (local repo config wins over global). `commitprefix`/`pathprefix` are required and `BaseURL` must be `http`/`https` with a non-empty host — any violation skips the provider entirely. `lineformat` is optional: zero, one, or two `%l` verbs are valid (more, or any other verb, is not) — a missing/invalid `lineformat` drops only that provider's line-anchor support (stderr warning), not the provider itself. `TestDefaultProviders` and `TestDefaultProvidersLineFormat` enforce this for built-in defaults.
 
-**Tests:** `TestGetURL` and `TestParsePath` in `open/open_test.go` run against the real checked-out repo — do not move `open/` without updating them. `TestGetURLErrors`, `TestGetURLBareRepo`, and `TestGetURLWorktree` spin up hermetic temp repos. `TestLoadProviders` isolates global git config via `GIT_CONFIG_GLOBAL`. `gitw` functions are thin wrappers over `go-git-cmd-wrapper`: `Toplevel`, `AbsoluteGitDir`, `RemoteURL`, `CurrentRef`, `ConfigGetRegexp`; empty `path` arg → cwd.
+**Tests:** `TestGetURL` and `TestParsePath` in `open/open_test.go` run against the real checked-out repo — do not move `open/` without updating them. `TestGetURLErrors`, `TestGetURLBareRepo`, and `TestGetURLWorktree` spin up hermetic temp repos. `TestGetURLWindowsAbsolutePath` is Windows-only (`t.Skip` elsewhere) and covers drive-letter path parsing. `TestFromConfig` and `TestFromConfigLocal` isolate global/local git config via `GIT_CONFIG_GLOBAL`. `gitw` functions are thin wrappers over `go-git-cmd-wrapper`: `Toplevel`, `AbsoluteGitDir`, `RemoteURL`, `CurrentRef`, `ConfigGetRegexp`; empty `path` arg → cwd.
 
 ## Do not
 
 - Use `exec.Command("git", ...)` directly — use `gitw` or `go-git-cmd-wrapper`.
 - Add logic to `main.go` beyond arg parsing and error printing.
-- Add a default provider without cases in `TestCommitURL`, `TestPathURL`, `TestRootURL` — for user-specific instances prefer `git config` over a hardcoded addition.
+- Add a default provider without cases in `TestCommitURL`, `TestPathURL`, `TestLineAnchor`, `TestRootURL`, `TestDefaultProvidersLineFormat` — for user-specific instances prefer `git config` over a hardcoded addition.
 - Hardcode path separators — use `filepath.ToSlash` when building URLs from filesystem paths.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,20 @@ $ git open
 Open a specific file or folder of a repository.
 
 ```console
-$ git open LICENSE
+$ git open main.go
 ```
 
 Open a specific commit of a repository.
 
 ```console
 $ git open 7605d91
+```
+
+Open a specific line, or range of lines, of a file.
+
+```console
+$ git open main.go:42
+$ git open main.go:42-50
 ```
 
 Open a different repository than `cwd`.
@@ -38,6 +45,7 @@ To add custom Git providers and their URLs, set their values within the global `
 [open "https://git.mydomain.dev"]
     commitprefix = commit
     pathprefix = tree
+    lineformat = L%l-L%l
 ```
 
 This can also be set using the `git` CLI.
@@ -45,6 +53,7 @@ This can also be set using the `git` CLI.
 ```console
 $ git config --global open.https://git.mydomain.dev.commitprefix commit
 $ git config --global open.https://git.mydomain.dev.pathprefix tree
+$ git config --global open.https://git.mydomain.dev.lineformat "L%l-L%l"
 ```
 
 `commitprefix` and `pathprefix` are used to template the URI for your provider.
@@ -55,6 +64,16 @@ fmt.Println(host + "/" + repository + "/" + commitprefix )
 
 fmt.Println(host + "/" + repository + "/" + pathprefix )
 // https://git.mydomain.dev/<repository>/tree
+```
+
+`lineformat` templates the line anchor where `%l` denotes the line number. Up to two
+`%l` may be provided, denoting the start and end lines. 3 or more `%l` or unsupported 
+Go-style verbs like `%v` will disable the line anchor templating and issue a warning.
+
+```go
+fmt.Sprintf(lineformat, startLine)          // one %l
+fmt.Sprintf(lineformat, startLine, endLine) // two %l
+// L42 or L42-L50
 ```
 
 ## Installation

--- a/open/open.go
+++ b/open/open.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/arbourd/git-get/get"
@@ -62,9 +63,10 @@ func GetURL(arg string) (string, error) {
 			t = Path
 		}
 	}
+	var lstart, lend int
 	if t == Path {
-		// Ignore parsePath errors: invalid or out-of-repo paths fall back to the root URL.
-		arg, _ = parsePath(arg, gitroot)
+		// Ignore parsePath errors: invalid or out-of-repo paths fall back to the root URL
+		arg, lstart, lend, _ = parsePath(arg, gitroot)
 	}
 
 	remote, ref, err := getRemoteRef(gitroot)
@@ -80,12 +82,12 @@ func GetURL(arg string) (string, error) {
 		return "", fmt.Errorf("local remotes are not supported")
 	}
 
-	providers := append(DefaultProviders, LoadProviders()...)
+	providers := Providers()
 
 	// Find the provider by exact host comparison.
 	var p Provider
 	for _, provider := range providers {
-		u, err := url.Parse(provider.BaseURL)
+		u, err := url.Parse(provider.BaseURL())
 		if err != nil {
 			continue
 		}
@@ -95,7 +97,7 @@ func GetURL(arg string) (string, error) {
 		}
 	}
 
-	if len(p.BaseURL) == 0 {
+	if len(p.BaseURL()) == 0 {
 		return "", fmt.Errorf("unable to find provider for: \"%s\"", host)
 	}
 
@@ -104,7 +106,7 @@ func GetURL(arg string) (string, error) {
 	case Commit:
 		openURL = p.CommitURL(repo, arg)
 	case Path:
-		openURL = p.PathURL(repo, ref, arg)
+		openURL = p.PathURL(repo, ref, arg, lstart, lend)
 	case Root:
 		openURL = p.RootURL(repo)
 	}
@@ -112,17 +114,30 @@ func GetURL(arg string) (string, error) {
 	return openURL, nil
 }
 
-// parsePath returns a cleaned path if the file and folder exist and belong to the root Git repository
-func parsePath(path, gitroot string) (string, error) {
+// parsePath returns the cleaned path, relative to the gitroot, and the parsed start and end line numbers
+func parsePath(path, gitroot string) (string, int, int, error) {
 	if path == "" {
-		return "", nil
+		return "", 0, 0, nil
+	}
+
+	var lstart, lend int
+	if stripped, start, end := stripLine(path); stripped != path {
+		// Prefer the literal, colon-suffixed argument when it names a real
+		// file or directory; otherwise treat the suffix as a line spec.
+		if _, statErr := os.Stat(path); statErr != nil {
+			path, lstart, lend = stripped, start, end
+		}
 	}
 	path = filepath.Clean(path)
 
-	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return "", err
+	info, err := os.Stat(path)
+	if err != nil && (os.IsNotExist(err) || ancestorIsFile(path)) {
+		return "", 0, 0, err
 	}
+	if err == nil && info.IsDir() {
+		lstart, lend = 0, 0
+	}
+
 	path, _ = filepath.Abs(path)
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		path = resolved
@@ -131,15 +146,32 @@ func parsePath(path, gitroot string) (string, error) {
 	// Check if path is within Git root
 	rel, err := filepath.Rel(gitroot, path)
 	if err != nil || strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("path does not contain gitroot: %s; %s", path, gitroot)
+		return "", 0, 0, fmt.Errorf("path does not contain gitroot: %s; %s", path, gitroot)
 	}
 
 	if rel == "." {
-		return "", nil
+		return "", 0, 0, nil
 	}
 
 	// Convert all path separators to `/` and trim trailing `/`
-	return filepath.ToSlash(rel), nil
+	return filepath.ToSlash(rel), lstart, lend, nil
+}
+
+// ancestorIsFile reports whether path is invalid directory because an ancestor
+// is a file -- POSIX's ENOTDIR or Windows' ERROR_PATH_NOT_FOUND
+func ancestorIsFile(path string) bool {
+	dir := filepath.Dir(path)
+	for {
+		parent, err := os.Stat(dir)
+		if err == nil {
+			return !parent.IsDir()
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			return false
+		}
+		dir = next
+	}
 }
 
 // getRemoteRef returns the Git remote and reference (branch, tag, commit), for a provided Git repository
@@ -162,6 +194,37 @@ func parseRepository(remote string) (host string, repo string, err error) {
 
 	repo = strings.TrimPrefix(strings.TrimSuffix(path.Clean(url.Path), ".git"), "/")
 	return url.Host, repo, nil
+}
+
+// lineSuffixRegex matches trailing line numbers
+var lineSuffixRegex = regexp.MustCompile(`^[0-9-]+$`)
+
+// stripLine splits a trailing line suffix from arg, returning the path and line numbers
+func stripLine(arg string) (path string, start int, end int) {
+	i := strings.LastIndex(arg, ":")
+	if i <= 0 {
+		return arg, 0, 0
+	}
+	path, suffix := arg[:i], arg[i+1:]
+	if !lineSuffixRegex.MatchString(suffix) {
+		return arg, 0, 0
+	}
+
+	before, after, isRange := strings.Cut(suffix, "-")
+
+	start, err := strconv.Atoi(before)
+	if err != nil || start < 1 {
+		return path, 0, 0
+	}
+	if !isRange {
+		return path, start, 0
+	}
+
+	end, err = strconv.Atoi(after)
+	if err != nil || end < 1 {
+		return path, start, 0
+	}
+	return path, start, end
 }
 
 var commitSHARegex = regexp.MustCompile(`^[0-9a-f]{7,64}$`)

--- a/open/open_test.go
+++ b/open/open_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -68,6 +69,30 @@ func TestGetURL(t *testing.T) {
 		},
 		"out of git dir absolute path": {
 			arg:         filepath.FromSlash(homedir),
+			expectedURL: "https://github.com/arbourd/git-open/tree/%s",
+		},
+		"file with line": {
+			arg:         "open_test.go:3",
+			expectedURL: "https://github.com/arbourd/git-open/tree/%s/open/open_test.go#L3",
+		},
+		"file with line range": {
+			arg:         "open_test.go:3-10",
+			expectedURL: "https://github.com/arbourd/git-open/tree/%s/open/open_test.go#L3-L10",
+		},
+		"file with line zero drops the line, keeps the file": {
+			arg:         "open_test.go:0",
+			expectedURL: "https://github.com/arbourd/git-open/tree/%s/open/open_test.go",
+		},
+		"file with reversed line range": {
+			arg:         "open_test.go:10-3",
+			expectedURL: "https://github.com/arbourd/git-open/tree/%s/open/open_test.go#L10-L3",
+		},
+		"non-numeric suffix is not a line spec, no literal match falls back to root": {
+			arg:         "open_test.go:abc",
+			expectedURL: "https://github.com/arbourd/git-open/tree/%s",
+		},
+		"literal colon filename with no matching file falls back to root": {
+			arg:         "notes:42",
 			expectedURL: "https://github.com/arbourd/git-open/tree/%s",
 		},
 	}
@@ -243,6 +268,32 @@ func TestGetURLWorktree(t *testing.T) {
 	}
 }
 
+func TestGetURLWindowsAbsolutePath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows drive-letter path parsing only applies on windows")
+	}
+
+	ref, err := gitw.CurrentRef(".")
+	if err != nil {
+		t.Fatalf("unable to get local ref for test: %v", err)
+	}
+
+	abs, err := filepath.Abs("open_test.go")
+	if err != nil {
+		t.Fatalf("unable to get absolute path: %v", err)
+	}
+
+	url, err := GetURL(abs + ":3-10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedURL := fmt.Sprintf("https://github.com/arbourd/git-open/tree/%s/open/open_test.go#L3-L10", ref)
+	if url != expectedURL {
+		t.Fatalf("unexpected url:\n\t(GOT): %#v\n\t(WNT): %#v", url, expectedURL)
+	}
+}
+
 func TestParseRepository(t *testing.T) {
 	cases := map[string]struct {
 		remote       string
@@ -356,6 +407,124 @@ func TestParseType(t *testing.T) {
 	}
 }
 
+func TestStripLine(t *testing.T) {
+	cases := map[string]struct {
+		arg           string
+		expectedPath  string
+		expectedStart int
+		expectedEnd   int
+	}{
+		"no line suffix": {
+			arg:          "main.go",
+			expectedPath: "main.go",
+		},
+		"single line": {
+			arg:           "main.go:3",
+			expectedPath:  "main.go",
+			expectedStart: 3,
+		},
+		"line range": {
+			arg:           "main.go:3-10",
+			expectedPath:  "main.go",
+			expectedStart: 3,
+			expectedEnd:   10,
+		},
+		"nested path with line range": {
+			arg:           "a/b/main.go:3-10",
+			expectedPath:  "a/b/main.go",
+			expectedStart: 3,
+			expectedEnd:   10,
+		},
+		"multiple colons splits on the last one": {
+			arg:           "a:b:3",
+			expectedPath:  "a:b",
+			expectedStart: 3,
+		},
+		"trailing colon falls back to full arg": {
+			arg:          "main.go:",
+			expectedPath: "main.go:",
+		},
+		"no path before colon falls back to full arg": {
+			arg:          ":3",
+			expectedPath: ":3",
+		},
+		"non-numeric suffix falls back to full arg": {
+			arg:          "main.go:abc",
+			expectedPath: "main.go:abc",
+		},
+		"non-numeric range end falls back to full arg": {
+			arg:          "main.go:5-abc",
+			expectedPath: "main.go:5-abc",
+		},
+		"windows absolute path with no line suffix falls back to full arg": {
+			arg:          `C:\Example\file.txt`,
+			expectedPath: `C:\Example\file.txt`,
+		},
+		"windows absolute path with line range": {
+			arg:           `C:\Example\file.txt:5-10`,
+			expectedPath:  `C:\Example\file.txt`,
+			expectedStart: 5,
+			expectedEnd:   10,
+		},
+		"windows absolute path with reversed range": {
+			arg:           `C:\Example\file.txt:10-3`,
+			expectedPath:  `C:\Example\file.txt`,
+			expectedStart: 10,
+			expectedEnd:   3,
+		},
+		"trailing hyphen falls back to start": {
+			arg:           "main.go:3-",
+			expectedPath:  "main.go",
+			expectedStart: 3,
+		},
+		"line zero drops to path": {
+			arg:          "main.go:0",
+			expectedPath: "main.go",
+		},
+		"range end zero falls back to start": {
+			arg:           "main.go:5-0",
+			expectedPath:  "main.go",
+			expectedStart: 5,
+		},
+		"range start zero drops to path": {
+			arg:          "main.go:0-10",
+			expectedPath: "main.go",
+		},
+		"reversed range is allowed": {
+			arg:           "main.go:10-3",
+			expectedPath:  "main.go",
+			expectedStart: 10,
+			expectedEnd:   3,
+		},
+		"reversed range close together is allowed": {
+			arg:           "main.go:5-1",
+			expectedPath:  "main.go",
+			expectedStart: 5,
+			expectedEnd:   1,
+		},
+		"negative start drops to path": {
+			arg:          "main.go:-1-5",
+			expectedPath: "main.go",
+		},
+		"equal range": {
+			arg:           "main.go:5-5",
+			expectedPath:  "main.go",
+			expectedStart: 5,
+			expectedEnd:   5,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			path, start, end := stripLine(c.arg)
+			if path != c.expectedPath || start != c.expectedStart || end != c.expectedEnd {
+				t.Fatalf("unexpected result:\n\t(GOT): path=%#v start=%#v end=%#v\n\t(WNT): path=%#v start=%#v end=%#v",
+					path, start, end, c.expectedPath, c.expectedStart, c.expectedEnd)
+			}
+		})
+	}
+}
+
 func TestParsePath(t *testing.T) {
 	gitroot, err := gitw.Toplevel(".")
 	if err != nil {
@@ -363,9 +532,11 @@ func TestParsePath(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		path         string
-		expectedPath string
-		wantErr      bool
+		path          string
+		expectedPath  string
+		expectedStart int
+		expectedEnd   int
+		wantErr       bool
 	}{
 		"empty argument": {
 			path:         "",
@@ -378,6 +549,11 @@ func TestParsePath(t *testing.T) {
 		"local file": {
 			path:         "open_test.go",
 			expectedPath: "open/open_test.go",
+		},
+		"local file with line": {
+			path:          "open_test.go:3",
+			expectedPath:  "open/open_test.go",
+			expectedStart: 3,
 		},
 		"relative file": {
 			path:         filepath.FromSlash("../LICENSE"),
@@ -397,17 +573,31 @@ func TestParsePath(t *testing.T) {
 			expectedPath: "",
 			wantErr:      true,
 		},
+		"path walks through a file": {
+			path:         filepath.FromSlash("open_test.go/foo"),
+			expectedPath: "",
+			wantErr:      true,
+		},
+		"git root with line is dropped": {
+			path:         filepath.FromSlash("../:5"),
+			expectedPath: "",
+		},
+		"directory with line is dropped": {
+			path:         filepath.FromSlash("../open:5"),
+			expectedPath: "open",
+		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			path, err := parsePath(c.path, gitroot)
+			path, start, end, err := parsePath(c.path, gitroot)
 			if err != nil && !c.wantErr {
 				t.Fatalf("unexpected error:\n\t(GOT): %s\n\t(WNT): nil", err)
 			} else if err == nil && c.wantErr {
 				t.Fatalf("expected error:\n\t(GOT): nil")
-			} else if path != c.expectedPath {
-				t.Fatalf("unexpected path:\n\t(GOT): %#v\n\t(WNT): %#v", path, c.expectedPath)
+			} else if path != c.expectedPath || start != c.expectedStart || end != c.expectedEnd {
+				t.Fatalf("unexpected result:\n\t(GOT): path=%#v start=%#v end=%#v\n\t(WNT): path=%#v start=%#v end=%#v",
+					path, start, end, c.expectedPath, c.expectedStart, c.expectedEnd)
 			}
 		})
 	}

--- a/open/provider.go
+++ b/open/provider.go
@@ -1,74 +1,109 @@
 package open
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/arbourd/git-open/gitw"
 )
 
-// DefaultProviders are a list of supported Providers
-var DefaultProviders = []Provider{
+// defaultProviders is a list of built-in Providers
+var defaultProviders = []Provider{
 	{
-		BaseURL:      "https://github.com",
-		CommitPrefix: "commit",
-		PathPrefix:   "tree",
+		baseURL:      "https://github.com",
+		commitPrefix: "commit",
+		pathPrefix:   "tree",
+
+		rawLineFormat:   "L%l-L%l",
+		lineFormat:      "#L%d",
+		lineFormatRange: "#L%d-L%d",
 	},
 	{
-		BaseURL:      "https://gitlab.com",
-		CommitPrefix: "-/commit",
-		PathPrefix:   "-/tree",
+		baseURL:      "https://gitlab.com",
+		commitPrefix: "-/commit",
+		pathPrefix:   "-/tree",
+
+		rawLineFormat:   "L%l-%l",
+		lineFormat:      "#L%d",
+		lineFormatRange: "#L%d-%d",
 	},
 	{
-		BaseURL:      "https://bitbucket.org",
-		CommitPrefix: "commits",
-		PathPrefix:   "src",
+		baseURL:      "https://bitbucket.org",
+		commitPrefix: "commits",
+		pathPrefix:   "src",
+
+		rawLineFormat:   "lines-%l:%l",
+		lineFormat:      "#lines-%d",
+		lineFormatRange: "#lines-%d:%d",
 	},
+}
+
+func Providers() []Provider {
+	return slices.Concat(defaultProviders, fromConfig())
 }
 
 // Provider represents the Git platforms domain and URL pathing.
 type Provider struct {
-	BaseURL      string
-	CommitPrefix string
-	PathPrefix   string
+	baseURL      string
+	commitPrefix string
+	pathPrefix   string
+
+	rawLineFormat   string
+	lineFormat      string
+	lineFormatRange string
+}
+
+// BaseURL returns the provider's base URL as a string
+func (p Provider) BaseURL() string {
+	return p.baseURL
 }
 
 // CommitURL returns URL of a commit as a string
 func (p Provider) CommitURL(repo, commitSHA string) string {
-	return escapePath(strings.Join([]string{p.BaseURL, repo, p.CommitPrefix, commitSHA}, "/"))
+	return escapePath(strings.Join([]string{p.baseURL, repo, p.commitPrefix, commitSHA}, "/"))
 }
 
-// PathURL returns URL of a file as a string
-func (p Provider) PathURL(repo, ref, path string) string {
-	return escapePath(strings.Join([]string{p.BaseURL, repo, p.PathPrefix, ref, path}, "/"))
+// PathURL returns URL of a file with line anchors as a string
+func (p Provider) PathURL(repo, ref, path string, lstart, lend int) string {
+	u := strings.Join([]string{p.baseURL, repo, p.pathPrefix, ref, path}, "/")
+	return escapePath(u) + p.lineAnchor(lstart, lend)
 }
 
 // RootURL returns URL of the root repository as a string
 func (p Provider) RootURL(repo string) string {
-	return escapePath(strings.Join([]string{p.BaseURL, repo}, "/"))
+	return escapePath(strings.Join([]string{p.baseURL, repo}, "/"))
 }
 
-// escapePath escapes the URL with url.PathEscape, but unescapes `/` and trims trailing `/`
-func escapePath(u string) string {
-	return strings.TrimSuffix(strings.ReplaceAll(url.PathEscape(u), "%2F", "/"), "/")
+// lineAnchor returns a URL anchor highlighting a line or range of lines like `#L3` or `#L3-L10`
+func (p Provider) lineAnchor(start, end int) string {
+	if start == 0 || p.lineFormat == "" {
+		return ""
+	}
+	if end == 0 || p.lineFormatRange == "" {
+		return fmt.Sprintf(p.lineFormat, start)
+	}
+	return fmt.Sprintf(p.lineFormatRange, start, end)
 }
 
-const getRegex = `^open\..*prefix$`
+const getRegex = `^open\..*(prefix|format)$`
 
-// LoadProviders returns a slice of [Provider] from the global Git config.
+// fromConfig returns a slice of [Provider] from the global Git config.
 //
-// The Git config structure includes a base URL as an argument, and commit prefix and path prefix keys and values.
+// The Git config structure includes a base URL as an argument, commit prefix, path prefix and line format string.
 //
 //	[open "https://git.mydomain.dev"]
 //	  commitprefix = commit
 //	  pathprefix = tree
-func LoadProviders() []Provider {
-	p := []Provider{}
+//	  lineformat = L%l-L%l
+func fromConfig() []Provider {
+	providers := []Provider{}
 	out := gitw.ConfigGetRegexp(getRegex)
 	if len(out) == 0 {
-		return p
+		return providers
 	}
 
 	var order []string
@@ -101,22 +136,100 @@ func LoadProviders() []Provider {
 
 		switch key {
 		case "commitprefix":
-			entry.CommitPrefix = value
+			entry.commitPrefix = value
 		case "pathprefix":
-			entry.PathPrefix = value
+			entry.pathPrefix = value
+		case "lineformat":
+			entry.rawLineFormat = value
 		}
 	}
 
 	for _, k := range order {
+		var skip bool
+
 		u, err := url.Parse(k)
 		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
-			fmt.Fprintf(os.Stderr, "warning: invalid provider URL in git config: %q\n", k)
+			fmt.Fprintf(os.Stderr, "warning: invalid provider URL in git config: %q, skipping provider\n", k)
+			skip = true
+		}
+
+		v := urls[k]
+		if v.commitPrefix == "" {
+			fmt.Fprintf(os.Stderr, "warning: provider %q is missing commitprefix in git config, skipping provider\n", k)
+			skip = true
+		}
+		if v.pathPrefix == "" {
+			fmt.Fprintf(os.Stderr, "warning: provider %q is missing pathprefix in git config, skipping provider\n", k)
+			skip = true
+		}
+		if skip {
 			continue
 		}
-		v := urls[k]
-		v.BaseURL = k
-		p = append(p, *v)
+
+		lineFormat, lineFormatRange, err := parseRawLineFormat(v.rawLineFormat)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: invalid lineformat for %q in git config: %v\n", k, err)
+		} else if lineFormat == "" {
+			fmt.Fprintf(os.Stderr, "warning: provider %q is missing lineformat in git config\n", k)
+		}
+
+		v.baseURL = k
+		v.lineFormat = lineFormat
+		v.lineFormatRange = lineFormatRange
+		providers = append(providers, *v)
 	}
 
-	return p
+	return providers
+}
+
+// parseRawLineFormat parses the single argument line format and range from the raw line format
+// with an html anchor or returns a validation error
+func parseRawLineFormat(rawLineFormat string) (lineFormat, lineFormatRange string, err error) {
+	count, err := validateLineFormat(rawLineFormat)
+	if err != nil {
+		return "", "", err
+	}
+	if count == 0 {
+		return "", "", nil
+	}
+	if !strings.HasPrefix(rawLineFormat, "#") {
+		rawLineFormat = "#" + rawLineFormat
+	}
+
+	rawLineFormat = ltod(rawLineFormat)
+	if strings.Count(rawLineFormat, "%d") != count {
+		return "", "", errors.New("ambiguous line format: escaped `%%` collides with `%d`")
+	}
+
+	if count == 1 {
+		return rawLineFormat, "", nil
+	}
+
+	lineFormat = strings.SplitAfterN(rawLineFormat, "%d", 2)[0]
+	return lineFormat, rawLineFormat, nil
+}
+
+// validateLineFormat returns the number of `%l` verbs in a lineformat string, or an error if
+// there are more than two verbs or any verb other than the fake `%l` is used
+func validateLineFormat(format string) (count int, err error) {
+	stripped := strings.ReplaceAll(format, "%%", "")
+	count = strings.Count(stripped, "%l")
+	if strings.Count(stripped, "%") != count {
+		return 0, fmt.Errorf("unsupported verb in line format: %q", format)
+	}
+	if count > 2 {
+		return 0, fmt.Errorf("too many %%l verbs in line format (max 2): %q", format)
+	}
+
+	return count, nil
+}
+
+// ltod convers the custom format `%l` verb to `%d`
+func ltod(s string) string {
+	return strings.ReplaceAll(s, "%l", "%d")
+}
+
+// escapePath escapes the URL with url.PathEscape, but unescapes `/` and trims trailing `/`
+func escapePath(u string) string {
+	return strings.TrimSuffix(strings.ReplaceAll(url.PathEscape(u), "%2F", "/"), "/")
 }

--- a/open/provider_test.go
+++ b/open/provider_test.go
@@ -18,18 +18,35 @@ import (
 const repo = "arbourd/git-open"
 
 func TestDefaultProviders(t *testing.T) {
-	for _, p := range DefaultProviders {
-		u, err := url.Parse(p.BaseURL)
+	for _, p := range defaultProviders {
+		u, err := url.Parse(p.BaseURL())
 		if err != nil {
-			t.Errorf("provider %q: invalid BaseURL: %v", p.BaseURL, err)
+			t.Errorf("provider %q: invalid baseURL: %v", p.baseURL, err)
 			continue
 		}
 		if u.Host == "" {
-			t.Errorf("provider %q: BaseURL has no host", p.BaseURL)
+			t.Errorf("provider %q: baseURL has no host", p.baseURL)
 		}
 		if u.Scheme != "http" && u.Scheme != "https" {
-			t.Errorf("provider %q: BaseURL scheme must be http or https, got %q", p.BaseURL, u.Scheme)
+			t.Errorf("provider %q: baseURL scheme must be http or https, got %q", p.baseURL, u.Scheme)
 		}
+	}
+}
+
+func TestDefaultProvidersLineFormat(t *testing.T) {
+	for _, p := range defaultProviders {
+		t.Run(p.baseURL, func(t *testing.T) {
+			lineFormat, lineFormatRange, err := parseRawLineFormat(p.rawLineFormat)
+			if err != nil {
+				t.Fatalf("unexpected error parsing rawLineFormat %q: %v", p.rawLineFormat, err)
+			}
+			if lineFormat != p.lineFormat {
+				t.Errorf("unexpected lineFormat:\n\t(GOT): %#v\n\t(WNT): %#v", lineFormat, p.lineFormat)
+			}
+			if lineFormatRange != p.lineFormatRange {
+				t.Errorf("unexpected lineFormatRange:\n\t(GOT): %#v\n\t(WNT): %#v", lineFormatRange, p.lineFormatRange)
+			}
+		})
 	}
 }
 
@@ -40,17 +57,17 @@ func TestCommitURL(t *testing.T) {
 		expectedURL string
 	}{
 		"github": {
-			p:           DefaultProviders[0],
+			p:           defaultProviders[0],
 			commit:      "7605d91",
 			expectedURL: "https://github.com/arbourd/git-open/commit/7605d91",
 		},
 		"gitlab": {
-			p:           DefaultProviders[1],
+			p:           defaultProviders[1],
 			commit:      "7605d91",
 			expectedURL: "https://gitlab.com/arbourd/git-open/-/commit/7605d91",
 		},
 		"bitbucket": {
-			p:           DefaultProviders[2],
+			p:           defaultProviders[2],
 			commit:      "7605d91",
 			expectedURL: "https://bitbucket.org/arbourd/git-open/commits/7605d91",
 		},
@@ -71,33 +88,135 @@ func TestPathURL(t *testing.T) {
 		p           Provider
 		ref         string
 		path        string
+		lstart      int
+		lend        int
 		expectedURL string
 	}{
 		"github": {
-			p:           DefaultProviders[0],
+			p:           defaultProviders[0],
 			ref:         "main",
-			path:        "LICENSE",
-			expectedURL: "https://github.com/arbourd/git-open/tree/main/LICENSE",
+			path:        "main.go",
+			expectedURL: "https://github.com/arbourd/git-open/tree/main/main.go",
+		},
+		"github with line anchor": {
+			p:           defaultProviders[0],
+			ref:         "main",
+			path:        "main.go",
+			lstart:      3,
+			expectedURL: "https://github.com/arbourd/git-open/tree/main/main.go#L3",
+		},
+		"github with line anchor range": {
+			p:           defaultProviders[0],
+			ref:         "main",
+			path:        "main.go",
+			lstart:      3,
+			lend:        5,
+			expectedURL: "https://github.com/arbourd/git-open/tree/main/main.go#L3-L5",
 		},
 		"gitlab": {
-			p:           DefaultProviders[1],
+			p:           defaultProviders[1],
 			ref:         "main",
-			path:        "LICENSE",
-			expectedURL: "https://gitlab.com/arbourd/git-open/-/tree/main/LICENSE",
+			path:        "main.go",
+			expectedURL: "https://gitlab.com/arbourd/git-open/-/tree/main/main.go",
 		},
 		"bitbucket": {
-			p:           DefaultProviders[2],
+			p:           defaultProviders[2],
 			ref:         "main",
-			path:        "LICENSE",
-			expectedURL: "https://bitbucket.org/arbourd/git-open/src/main/LICENSE",
+			path:        "main.go",
+			expectedURL: "https://bitbucket.org/arbourd/git-open/src/main/main.go",
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			url := c.p.PathURL(repo, c.ref, c.path)
+			url := c.p.PathURL(repo, c.ref, c.path, c.lstart, c.lend)
 			if url != c.expectedURL {
 				t.Fatalf("unexpected url:\n\t(GOT): %#v\n\t(WNT): %#v", url, c.expectedURL)
+			}
+		})
+	}
+}
+
+func TestLineAnchor(t *testing.T) {
+	cases := map[string]struct {
+		p           Provider
+		start       int
+		end         int
+		expectedURL string
+	}{
+		"github no line": {
+			p:           defaultProviders[0],
+			start:       0,
+			end:         0,
+			expectedURL: "",
+		},
+		"github single line": {
+			p:           defaultProviders[0],
+			start:       3,
+			end:         0,
+			expectedURL: "#L3",
+		},
+		"github range": {
+			p:           defaultProviders[0],
+			start:       3,
+			end:         10,
+			expectedURL: "#L3-L10",
+		},
+		"gitlab single line": {
+			p:           defaultProviders[1],
+			start:       3,
+			end:         0,
+			expectedURL: "#L3",
+		},
+		"gitlab range": {
+			p:           defaultProviders[1],
+			start:       3,
+			end:         10,
+			expectedURL: "#L3-10",
+		},
+		"bitbucket single line": {
+			p:           defaultProviders[2],
+			start:       3,
+			end:         0,
+			expectedURL: "#lines-3",
+		},
+		"bitbucket range": {
+			p:           defaultProviders[2],
+			start:       3,
+			end:         10,
+			expectedURL: "#lines-3:10",
+		},
+		"single-verb format single line": {
+			p:           Provider{lineFormat: "#line-%d"},
+			start:       3,
+			end:         0,
+			expectedURL: "#line-3",
+		},
+		"single-verb format ignores range end": {
+			p:           Provider{lineFormat: "#line-%d"},
+			start:       3,
+			end:         10,
+			expectedURL: "#line-3",
+		},
+		"empty line format": {
+			p:           Provider{},
+			start:       3,
+			end:         0,
+			expectedURL: "",
+		},
+		"reverse start and end": {
+			p:           Provider{},
+			start:       3,
+			end:         0,
+			expectedURL: "",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			url := c.p.lineAnchor(c.start, c.end)
+			if url != c.expectedURL {
+				t.Fatalf("unexpected anchor:\n\t(GOT): %#v\n\t(WNT): %#v", url, c.expectedURL)
 			}
 		})
 	}
@@ -109,15 +228,15 @@ func TestRootURL(t *testing.T) {
 		expectedURL string
 	}{
 		"github": {
-			p:           DefaultProviders[0],
+			p:           defaultProviders[0],
 			expectedURL: "https://github.com/arbourd/git-open",
 		},
 		"gitlab": {
-			p:           DefaultProviders[1],
+			p:           defaultProviders[1],
 			expectedURL: "https://gitlab.com/arbourd/git-open",
 		},
 		"bitbucket": {
-			p:           DefaultProviders[2],
+			p:           defaultProviders[2],
 			expectedURL: "https://bitbucket.org/arbourd/git-open",
 		},
 	}
@@ -129,6 +248,218 @@ func TestRootURL(t *testing.T) {
 				t.Fatalf("unexpected url:\n\t(GOT): %#v\n\t(WNT): %#v", url, c.expectedURL)
 			}
 		})
+	}
+}
+
+func TestFromConfig(t *testing.T) {
+	root := t.TempDir()
+	gitconfig := filepath.Join(root, ".gitconfig")
+
+	if runtime.GOOS == "darwin" {
+		err := os.Setenv("XDG_CONFIG_HOME", root)
+		if err != nil {
+			t.Fatalf("unable to set XDG_CONFIG_HOME: %s", err)
+		}
+	}
+
+	// Skip fixture on Windows in CI
+	if !(os.Getenv("CI") == "true" && runtime.GOOS == "windows") {
+		_, err := os.Create(gitconfig)
+		if err != nil {
+			t.Fatalf("unable create .gitconfig: %s", err)
+		}
+
+		err = os.Setenv("GIT_CONFIG_GLOBAL", gitconfig)
+		if err != nil {
+			t.Fatalf("unable to set GIT_CONFIG_GLOBAL: %s", err)
+		}
+	}
+
+	cases := map[string]struct {
+		config            []string
+		expectedProviders []Provider
+	}{
+		"empty git config": {
+			expectedProviders: []Provider{},
+		},
+		"single provider": {
+			config: []string{
+				"open.https://my.domain.dev.commitprefix -/commit",
+				"open.https://my.domain.dev.pathprefix -/tree",
+				"open.https://my.domain.dev.lineformat L%l-L%l",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://my.domain.dev", commitPrefix: "-/commit", pathPrefix: "-/tree", rawLineFormat: "L%l-L%l", lineFormat: "#L%d", lineFormatRange: "#L%d-L%d"},
+			},
+		},
+		"single provider with # prefix": {
+			config: []string{
+				"open.https://my.domain.dev.commitprefix -/commit",
+				"open.https://my.domain.dev.pathprefix -/tree",
+				"open.https://my.domain.dev.lineformat #L%l-L%l",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://my.domain.dev", commitPrefix: "-/commit", pathPrefix: "-/tree", rawLineFormat: "#L%l-L%l", lineFormat: "#L%d", lineFormatRange: "#L%d-L%d"},
+			},
+		},
+		"multiple providers": {
+			config: []string{
+				"open.https://git.example1.dev.commitprefix -/commit",
+				"open.https://git.example1.dev.pathprefix -/tree",
+				"open.https://git.example1.dev.lineformat L%l-L%l",
+				"open.https://git.example2.dev.commitprefix commit",
+				"open.https://git.example2.dev.pathprefix tree",
+				"open.https://git.example2.dev.lineformat L%l-L%l",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://git.example1.dev", commitPrefix: "-/commit", pathPrefix: "-/tree", rawLineFormat: "L%l-L%l", lineFormat: "#L%d", lineFormatRange: "#L%d-L%d"},
+				{baseURL: "https://git.example2.dev", commitPrefix: "commit", pathPrefix: "tree", rawLineFormat: "L%l-L%l", lineFormat: "#L%d", lineFormatRange: "#L%d-L%d"},
+			},
+		},
+		"multiple subdomains": {
+			config: []string{
+				"open.https://git.internal.corp.com.commitprefix commit",
+				"open.https://git.internal.corp.com.pathprefix tree",
+				"open.https://git.internal.corp.com.lineformat L%l-L%l",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://git.internal.corp.com", commitPrefix: "commit", pathPrefix: "tree", rawLineFormat: "L%l-L%l", lineFormat: "#L%d", lineFormatRange: "#L%d-L%d"},
+			},
+		},
+		"custom single-verb line format": {
+			config: []string{
+				"open.https://git.example3.dev.commitprefix commit",
+				"open.https://git.example3.dev.pathprefix tree",
+				"open.https://git.example3.dev.lineformat line-%l",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://git.example3.dev", commitPrefix: "commit", pathPrefix: "tree", rawLineFormat: "line-%l", lineFormat: "#line-%d", lineFormatRange: ""},
+			},
+		},
+		"custom two-verb line format doubles as range format": {
+			config: []string{
+				"open.https://git.example4.dev.commitprefix commit",
+				"open.https://git.example4.dev.pathprefix tree",
+				"open.https://git.example4.dev.lineformat #line-%l:%l",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://git.example4.dev", commitPrefix: "commit", pathPrefix: "tree", rawLineFormat: "#line-%l:%l", lineFormat: "#line-%d", lineFormatRange: "#line-%d:%d"},
+			},
+		},
+		"invalid url": {
+			config: []string{
+				"open.not-a-url.commitprefix commit",
+				"open.not-a-url.pathprefix tree",
+				"open.not-a-url.lineformat L%l-L%l",
+			},
+			expectedProviders: []Provider{},
+		},
+		"non-web scheme": {
+			config: []string{
+				"open.ssh://git.example.dev.commitprefix commit",
+				"open.ssh://git.example.dev.pathprefix tree",
+				"open.ssh://git.example.dev.lineformat L%l-L%l",
+			},
+			expectedProviders: []Provider{},
+		},
+		"empty line format is ignored but not dropped": {
+			config: []string{
+				"open.https://git.example6.dev.commitprefix commit",
+				"open.https://git.example6.dev.pathprefix tree",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://git.example6.dev", commitPrefix: "commit", pathPrefix: "tree", rawLineFormat: "", lineFormat: "", lineFormatRange: ""},
+			},
+		},
+		"invalid line format is ignored but not dropped": {
+			config: []string{
+				"open.https://git.example6.dev.commitprefix commit",
+				"open.https://git.example6.dev.pathprefix tree",
+				"open.https://git.example6.dev.lineformat #L%s",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://git.example6.dev", commitPrefix: "commit", pathPrefix: "tree", rawLineFormat: "#L%s", lineFormat: "", lineFormatRange: ""},
+			},
+		},
+		"line format with too many verbs is ignored but not dropped": {
+			config: []string{
+				"open.https://git.example7.dev.commitprefix commit",
+				"open.https://git.example7.dev.pathprefix tree",
+				"open.https://git.example7.dev.lineformat #L%d-%d-%d",
+			},
+			expectedProviders: []Provider{
+				{baseURL: "https://git.example7.dev", commitPrefix: "commit", pathPrefix: "tree", rawLineFormat: "#L%d-%d-%d", lineFormat: "", lineFormatRange: ""},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			// removes all `open.https://` Git config entries
+			out, _ := git.Config(config.Global, config.GetRegexp(getRegex, ""))
+			for v := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+				key, _, _ := strings.Cut(strings.TrimSpace(v), " ")
+				git.Config(config.Global, config.Unset(key, ""))
+			}
+
+			for _, v := range c.config {
+				key, val, _ := strings.Cut(v, " ")
+				git.Config(config.Global, config.Entry(key, val))
+			}
+
+			p := fromConfig()
+			if len(p) != len(c.expectedProviders) {
+				t.Logf("unexpected number of providers\n\t(GOT): %#v\n\t(WNT): %#v", len(p), len(c.expectedProviders))
+			}
+			sortOpt := cmpopts.SortSlices(func(a, b Provider) bool { return a.baseURL < b.baseURL })
+			if !cmp.Equal(p, c.expectedProviders, sortOpt, cmp.AllowUnexported(Provider{})) {
+				t.Fatalf("unexpected providers:\n\t(GOT): %#v\n\t(WNT): %#v", p, c.expectedProviders)
+			}
+		})
+	}
+}
+
+func TestFromConfigLocal(t *testing.T) {
+	// Redirect global config to an empty file so only local config is visible.
+	globalConfig := filepath.Join(t.TempDir(), ".gitconfig")
+	f, err := os.Create(globalConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("config", "open.https://local.example.dev.commitprefix", "commit")
+	run("config", "open.https://local.example.dev.pathprefix", "tree")
+	run("config", "open.https://local.example.dev.lineformat", "L%l-L%l")
+
+	t.Chdir(dir)
+
+	providers := fromConfig()
+	expected := []Provider{{
+		baseURL:         "https://local.example.dev",
+		commitPrefix:    "commit",
+		pathPrefix:      "tree",
+		rawLineFormat:   "L%l-L%l",
+		lineFormat:      "#L%d",
+		lineFormatRange: "#L%d-L%d",
+	}}
+
+	sortOpt := cmpopts.SortSlices(func(a, b Provider) bool { return a.baseURL < b.baseURL })
+	if !cmp.Equal(providers, expected, sortOpt, cmp.AllowUnexported(Provider{})) {
+		t.Fatalf("unexpected providers:\n\t(GOT): %#v\n\t(WNT): %#v", providers, expected)
 	}
 }
 
@@ -165,145 +496,158 @@ func TestEscapePath(t *testing.T) {
 	}
 }
 
-func TestLoadProviders(t *testing.T) {
-	root := t.TempDir()
-	gitconfig := filepath.Join(root, ".gitconfig")
-
-	if runtime.GOOS == "darwin" {
-		err := os.Setenv("XDG_CONFIG_HOME", root)
-		if err != nil {
-			t.Fatalf("unable to set XDG_CONFIG_HOME: %s", err)
-		}
-	}
-
-	// Skip fixture on Windows in CI
-	if !(os.Getenv("CI") == "true" && runtime.GOOS == "windows") {
-		_, err := os.Create(gitconfig)
-		if err != nil {
-			t.Fatalf("unable create .gitconfig: %s", err)
-		}
-
-		err = os.Setenv("GIT_CONFIG_GLOBAL", gitconfig)
-		if err != nil {
-			t.Fatalf("unable to set GIT_CONFIG_GLOBAL: %s", err)
-		}
-	}
-
+func TestParseRawLineFormat(t *testing.T) {
 	cases := map[string]struct {
-		config            []string
-		expectedProviders []Provider
+		rawLineFormat       string
+		expectedLineFormat  string
+		expectedRangeFormat string
+		expectErr           bool
 	}{
-		"empty git config": {
-			expectedProviders: []Provider{},
+		"single verb": {
+			rawLineFormat:      "L%l",
+			expectedLineFormat: "#L%d",
 		},
-		"single provider": {
-			config: []string{
-				"open.https://my.domain.dev.commitprefix -/commit",
-				"open.https://my.domain.dev.pathprefix -/tree",
-			},
-			expectedProviders: []Provider{
-				{BaseURL: "https://my.domain.dev", CommitPrefix: "-/commit", PathPrefix: "-/tree"},
-			},
+		"single verb already has #": {
+			rawLineFormat:      "#L%l",
+			expectedLineFormat: "#L%d",
 		},
-		"multiple providers": {
-			config: []string{
-				"open.https://git.example1.dev.commitprefix -/commit",
-				"open.https://git.example1.dev.pathprefix -/tree",
-				"open.https://git.example2.dev.commitprefix commit",
-				"open.https://git.example2.dev.pathprefix tree",
-			},
-			expectedProviders: []Provider{
-				{BaseURL: "https://git.example1.dev", CommitPrefix: "-/commit", PathPrefix: "-/tree"},
-				{BaseURL: "https://git.example2.dev", CommitPrefix: "commit", PathPrefix: "tree"},
-			},
+		"two verbs": {
+			rawLineFormat:       "L%l-L%l",
+			expectedLineFormat:  "#L%d",
+			expectedRangeFormat: "#L%d-L%d",
 		},
-		"multiple subdomains": {
-			config: []string{
-				"open.https://git.internal.corp.com.commitprefix commit",
-				"open.https://git.internal.corp.com.pathprefix tree",
-			},
-			expectedProviders: []Provider{
-				{BaseURL: "https://git.internal.corp.com", CommitPrefix: "commit", PathPrefix: "tree"},
-			},
+		"two verbs already has #": {
+			rawLineFormat:       "#L%l-L%l",
+			expectedLineFormat:  "#L%d",
+			expectedRangeFormat: "#L%d-L%d",
 		},
-		"invalid url": {
-			config: []string{
-				"open.not-a-url.commitprefix commit",
-				"open.not-a-url.pathprefix tree",
-			},
-			expectedProviders: []Provider{},
+		"no verbs": {
+			rawLineFormat: "L",
 		},
-		"non-web scheme": {
-			config: []string{
-				"open.ssh://git.example.dev.commitprefix commit",
-				"open.ssh://git.example.dev.pathprefix tree",
-			},
-			expectedProviders: []Provider{},
+		"too many verbs": {
+			rawLineFormat: "L%l-%l-%l",
+			expectErr:     true,
+		},
+		"disallowed verb": {
+			rawLineFormat: "L%s",
+			expectErr:     true,
+		},
+		"escaped percent adjacent to verb": {
+			rawLineFormat: "%%d%l-%l",
+			expectErr:     true,
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			// removes all `open.https://` Git config entries
-			out, _ := git.Config(config.Global, config.GetRegexp(getRegex, ""))
-			for v := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
-				key, _, _ := strings.Cut(strings.TrimSpace(v), " ")
-				git.Config(config.Global, config.Unset(key, ""))
+			lineFormat, lineFormatRange, err := parseRawLineFormat(c.rawLineFormat)
+			if c.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
 			}
-
-			for _, v := range c.config {
-				key, val, _ := strings.Cut(v, " ")
-				git.Config(config.Global, config.Entry(key, val))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
-
-			p := LoadProviders()
-			if len(p) != len(c.expectedProviders) {
-				t.Logf("unexpected number of providers\n\t(GOT): %#v\n\t(WNT): %#v", len(p), len(c.expectedProviders))
+			if lineFormat != c.expectedLineFormat {
+				t.Errorf("unexpected lineFormat:\n\t(GOT): %#v\n\t(WNT): %#v", lineFormat, c.expectedLineFormat)
 			}
-			sortOpt := cmpopts.SortSlices(func(a, b Provider) bool { return a.BaseURL < b.BaseURL })
-			if !cmp.Equal(p, c.expectedProviders, sortOpt) {
-				t.Fatalf("unexpected providers:\n\t(GOT): %#v\n\t(WNT): %#v", p, c.expectedProviders)
+			if lineFormatRange != c.expectedRangeFormat {
+				t.Errorf("unexpected lineFormatRange:\n\t(GOT): %#v\n\t(WNT): %#v", lineFormatRange, c.expectedRangeFormat)
 			}
 		})
 	}
 }
 
-func TestLoadProvidersLocal(t *testing.T) {
-	// Redirect global config to an empty file so only local config is visible.
-	globalConfig := filepath.Join(t.TempDir(), ".gitconfig")
-	f, err := os.Create(globalConfig)
-	if err != nil {
-		t.Fatal(err)
+func TestValidateLineFormat(t *testing.T) {
+	cases := map[string]struct {
+		format        string
+		expectedCount int
+		expectErr     bool
+	}{
+		"no verbs": {
+			format:        "L",
+			expectedCount: 0,
+		},
+		"one verb": {
+			format:        "L%l",
+			expectedCount: 1,
+		},
+		"two verbs": {
+			format:        "L%l-%l",
+			expectedCount: 2,
+		},
+		"three verbs": {
+			format:    "L%l-%l-%l",
+			expectErr: true,
+		},
+		"escaped percent is not a verb": {
+			format:        "L%%%l",
+			expectedCount: 1,
+		},
+		"trailing percent": {
+			format:    "L%",
+			expectErr: true,
+		},
+		"disallowed verb %s": {
+			format:    "L%s",
+			expectErr: true,
+		},
+		"disallowed verb %q": {
+			format:    "L%q",
+			expectErr: true,
+		},
+		"disallowed verb with flags %#v": {
+			format:    "L%#v",
+			expectErr: true,
+		},
 	}
-	f.Close()
-	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
 
-	dir := t.TempDir()
-	run := func(args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			count, err := validateLineFormat(c.format)
+			if c.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if count != c.expectedCount {
+				t.Errorf("unexpected count:\n\t(GOT): %#v\n\t(WNT): %#v", count, c.expectedCount)
+			}
+		})
 	}
-	run("init")
-	run("config", "user.email", "test@example.com")
-	run("config", "user.name", "Test")
-	run("config", "open.https://local.example.dev.commitprefix", "commit")
-	run("config", "open.https://local.example.dev.pathprefix", "tree")
+}
 
-	t.Chdir(dir)
+func TestLtod(t *testing.T) {
+	cases := map[string]struct {
+		s        string
+		expected string
+	}{
+		"single verb": {
+			s:        "#L%l",
+			expected: "#L%d",
+		},
+		"two verbs": {
+			s:        "#L%l-L%l",
+			expected: "#L%d-L%d",
+		},
+		"no verb": {
+			s:        "#L%d",
+			expected: "#L%d",
+		},
+	}
 
-	providers := LoadProviders()
-	expected := []Provider{{
-		BaseURL:      "https://local.example.dev",
-		CommitPrefix: "commit",
-		PathPrefix:   "tree",
-	}}
-
-	sortOpt := cmpopts.SortSlices(func(a, b Provider) bool { return a.BaseURL < b.BaseURL })
-	if !cmp.Equal(providers, expected, sortOpt) {
-		t.Fatalf("unexpected providers:\n\t(GOT): %#v\n\t(WNT): %#v", providers, expected)
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ltod(c.s)
+			if got != c.expected {
+				t.Errorf("unexpected result:\n\t(GOT): %#v\n\t(WNT): %#v", got, c.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Support opening a specific line or range of lines by suffixing a path with :n-n like `git open main.go:42` or `git open main.go:42-50`.

Each provider now defines their anchor line format as a config option: `open.<url>.lineformat`
